### PR TITLE
[20171020] skip useless cmd args

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"unicode"
 
 	"github.com/fatih/color"
@@ -79,18 +80,34 @@ func loadEnv() {
 
 func parseArgs(args []string) ([]string, bool, bool) {
 	//match argument: -v or -m
-	n := 0
 	var withVoice, withMore bool
-	for i := len(args) - 1; i > 0; i-- {
-		if args[i] == "-v" {
-			withVoice = true
-			n++
-		} else if args[i] == "-m" {
-			withMore = true
-			n++
-		} else {
-			break
+	parameterStartIndex := findParamStartIndex(args)
+	paramArray := args[parameterStartIndex:]
+	if elementInStringArray(paramArray, "-m") {
+		withMore = true
+	}
+
+	if elementInStringArray(paramArray, "-v") {
+		withVoice = true
+	}
+	return args[1:parameterStartIndex], withVoice, withMore
+}
+
+func findParamStartIndex(args []string) int {
+	// iter the args array, if an element is -m or -v, then  all of the latter elements must be parameter instead of words.
+	for index, word := range args {
+		if strings.HasPrefix(word, "-") && len(word) == 2 {
+			return index
 		}
 	}
-	return args[1 : len(args)-n], withVoice, withMore
+	return len(args)
+}
+
+func elementInStringArray(stringArray []string, element string) bool {
+	for _, word := range stringArray {
+		if word == element {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
 [description]
 目前可用的参数包括`-v` 和 `-m`，根据util.go里面`parseArgs`的
 逻辑，这两个参数必需在最后才能被正常识别。因此，如果使用的命令为

 ```
 ydict hello -m -x
 ```

 那么将会什么也无法得到。但如果使用:
 ```
 ydict hello -x -m
 ```
 那么程序会把`hello -x`作为一个参数来进行查询。

 [action]
 这个PR的做法是，首先把单词和参数分开。区分的办法如下:

 寻找args里面，以-开头，并且只有一个字母的元素，它就是第一个参数

 第一个参数之前的部分就是`ydict 单词`或者 `ydict 词组`
 第一个参数和它之后的部分全部是参数

 之所以采用这个策略，是因为有一些英文后缀也是可以查询的，例如"-tion"，为了
 区分参数和英文后缀，这里采用Linux里面的参数方案，单字母参数用一个-开头，
 多字母参数用--开头。因此，如果args里面某个元素为-开头且只有一个字母，则必为参数。

 [result]
 1. 单元测试全部通过
 2. 打上这个PR以后，-v 和 -m 的顺序将会无关紧要
 3. 无效的参数会自动忽略

- [x] 我已确保代码能本地编译通过，并无编译错误.
- [x] 我已确认运行现有测试用例，并且所有测试用例均能通过.
- [x] 我已确认遵循Go语言代码编写规范，保证代码可读且可维护.
