### PR TITLE
Show word's part of speech

### DIFF
--- a/query.go
+++ b/query.go
@@ -92,8 +92,17 @@ func query(words []string, withVoice, withMore, isMulti bool) {
 	if isChinese {
 		// Find the result
 		fmt.Println()
-		doc.Find(".trans-container > ul > p > span.contentTitle").Each(func(i int, s *goquery.Selection) {
-			color.Green("    %s", s.Find(".search-js").Text())
+		doc.Find(".trans-container > ul > p").Each(func(i int, s *goquery.Selection) {
+			partOfSpeech := s.Children().Not(".contentTitle").Text()
+			if partOfSpeech != "" {
+				fmt.Printf("%14s ", color.MagentaString(partOfSpeech))
+			}
+
+			meanings := []string{}
+			s.Find(".contentTitle > .search-js").Each(func(ii int, ss *goquery.Selection) {
+				meanings = append(meanings, ss.Text())
+			})
+			fmt.Printf("%s\n", color.GreenString(strings.Join(meanings, "; ")))
 		})
 	} else {
 


### PR DESCRIPTION
- [x] 我已确保代码能本地编译通过，并无编译错误.
- [x] 我已确认运行现有测试用例，并且所有测试用例均能通过.
- [x] 我已确认遵循Go语言代码编写规范，保证代码可读且可维护.

中译英时，显示单词的词性。