### PR TITLE
add quite mode, use unix like params style

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	words, withVoice, withMore := parseArgs(os.Args)
-	query(words, withVoice, withMore, len(words) > 1)
+	words, withVoice, withMore, isQuiet := parseArgs(os.Args[1:])
+	query(words, withVoice, withMore, isQuiet, len(words) > 1)
 }

--- a/query.go
+++ b/query.go
@@ -21,7 +21,7 @@ var (
 	voiceURL = "https://dict.youdao.com/dictvoice?audio=%s&type=2"
 )
 
-func query(words []string, withVoice, withMore, isMulti bool) {
+func query(words []string, withVoice, withMore, isQuiet, isMulti bool) {
 	var url string
 	var doc *goquery.Document
 	var voiceBody io.ReadCloser
@@ -38,13 +38,16 @@ func query(words []string, withVoice, withMore, isMulti bool) {
 	}
 
 	//Init spinner
-	s := spinner.New(spinner.CharSets[35], 100*time.Millisecond)
-	s.Prefix = "Querying... "
-	if err := s.Color("green"); err != nil {
-		color.Red("Failed to set color for spinner")
-		os.Exit(1)
+	var s *spinner.Spinner
+	if !isQuiet {
+		s = spinner.New(spinner.CharSets[35], 100*time.Millisecond)
+		s.Prefix = "Querying... "
+		if err := s.Color("green"); err != nil {
+			color.Red("Failed to set color for spinner")
+			os.Exit(1)
+		}
+		s.Start()
 	}
-	s.Start()
 
 	//Check proxy
 	if proxy != "" {
@@ -90,7 +93,9 @@ func query(words []string, withVoice, withMore, isMulti bool) {
 		}
 	}
 
-	s.Stop()
+	if !isQuiet {
+		s.Stop()
+	}
 
 	if isChinese {
 		// Find the result

--- a/utils.go
+++ b/utils.go
@@ -34,8 +34,9 @@ func displayUsage() {
 	color.Cyan(logo, Version)
 	color.Cyan("Usage:")
 	color.Cyan("ydict <word(s) to query>        Query the word(s)")
-	color.Cyan("ydict <word(s) to query> -v     Query with speech")
-	color.Cyan("ydict <word(s) to query> -m     Query with more example sentences")
+	color.Cyan("ydict -v <word(s) to query>     Query with speech")
+	color.Cyan("ydict -m <word(s) to query>     Query with more example sentences")
+	color.Cyan("ydict -q <word(s) to query>     Query with quiet mode, don't show spinner")
 	color.Cyan("ydict -h                        For help")
 }
 
@@ -79,11 +80,11 @@ func loadEnv() {
 	proxy = os.Getenv("SOCKS5")
 }
 
-func parseArgs(args []string) ([]string, bool, bool) {
-	//match argument: -v or -m
-	var withVoice, withMore bool
-	parameterStartIndex := findParamStartIndex(args)
-	paramArray := args[parameterStartIndex:]
+func parseArgs(args []string) ([]string, bool, bool, bool) {
+	//match argument: -v or -m or -q
+	var withVoice, withMore, isQuiet bool
+	wordStartIndex := findWordStartIndex(args)
+	paramArray := args[:wordStartIndex]
 	if elementInStringArray(paramArray, "-m") {
 		withMore = true
 	}
@@ -91,14 +92,19 @@ func parseArgs(args []string) ([]string, bool, bool) {
 	if elementInStringArray(paramArray, "-v") {
 		withVoice = true
 	}
-	return args[1:parameterStartIndex], withVoice, withMore
+
+	if elementInStringArray(paramArray, "-q") {
+		isQuiet = true
+	}
+
+	return args[wordStartIndex:], withVoice, withMore, isQuiet
 }
 
-func findParamStartIndex(args []string) int {
-	// iter the args array, if an element is -m or -v,
+func findWordStartIndex(args []string) int {
+	// iter the args array, if an element is -m or -v or -q,
 	// then all of the latter elements must be parameter instead of words.
 	for index, word := range args {
-		if strings.HasPrefix(word, "-") && len(word) == 2 {
+		if !strings.HasPrefix(word, "-") {
 			return index
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -27,30 +27,28 @@ func TestParseArgs(t *testing.T) {
 	// Only pass t into top-level Convey calls
 	Convey("Init args arrays: withVoice & withOutVoice", t, func() {
 		withoutAll := []string{"aa", "bb", "cc"}
-		withAll := []string{"aa", "bb", "-v", "-m"}
-
-		withVoice := []string{"aa", "bb", "-v"}
-		withMore := []string{"aa", "bb", "-m"}
+		withAll := []string{"-v", "-m", "-q", "aa", "bb"}
 
 		Convey("Call parse func", func() {
-			_, ret1, ret2 := parseArgs(withoutAll)
-			_, ret3, ret4 := parseArgs(withAll)
-
-			_, ret5, ret6 := parseArgs(withVoice)
-			_, ret7, ret8 := parseArgs(withMore)
+			words01, ret01, ret02, ret03 := parseArgs(withoutAll)
+			words11, ret11, ret12, ret13 := parseArgs(withAll)
 
 			Convey("result should be: true & false", func() {
-				So(ret1, ShouldEqual, false)
-				So(ret2, ShouldEqual, false)
+				So(words01, ShouldContain, "aa")
+				So(words01, ShouldContain, "bb")
+				So(words01, ShouldContain, "cc")
+				So(ret01, ShouldEqual, false)
+				So(ret02, ShouldEqual, false)
+				So(ret03, ShouldEqual, false)
 
-				So(ret3, ShouldEqual, true)
-				So(ret4, ShouldEqual, true)
-
-				So(ret5, ShouldEqual, true)
-				So(ret6, ShouldEqual, false)
-
-				So(ret7, ShouldEqual, false)
-				So(ret8, ShouldEqual, true)
+				So(words11, ShouldContain, "aa")
+				So(words11, ShouldContain, "bb")
+				So(words11, ShouldNotContain, "-v")
+				So(words11, ShouldNotContain, "-m")
+				So(words11, ShouldNotContain, "-q")
+				So(ret11, ShouldEqual, true)
+				So(ret12, ShouldEqual, true)
+				So(ret13, ShouldEqual, true)
 			})
 		})
 	})


### PR DESCRIPTION
- [x] 我已确保代码能本地编译通过，并无编译错误.
- [x] 我已确认运行现有测试用例，并且所有测试用例均能通过.
- [x] 我已确认遵循Go语言代码编写规范，保证代码可读且可维护.

增加了 quiet 模式，不显示 spinner，更模式适合与其他程序集成
修改了参数风格，更符合 unix 风格，这种风格使脚本化更简单，因为单词参数是追加而不是插入

我的使用场景是在 tmux 中查询选中的单词

```
tmux bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "xargs -I {} tmux run-shell -b 'ydict -q {}'"
```

https://github.com/xieyunzi/dotfiles/blob/84036b19af28c6fd1f37e7072a64b5cee040321a/tmux/.tmux.conf#L88

